### PR TITLE
fix omission of data

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def encode():
 
     # Calculate the padding needed
     original_bytes = len(original_data)
-    padding_bytes = int(math.pow(math.isqrt(original_bytes) + 1, 2) - original_bytes) * 3
+    padding_bytes = (int(math.pow(math.isqrt(original_bytes) + 1, 2) - original_bytes)+1) * 3
 
     # pad the byte data
     byte_data = original_data + b'\x00' * padding_bytes

--- a/main.py
+++ b/main.py
@@ -24,15 +24,15 @@ def encode():
         return  # Added return to prevent further execution
 
     # Calculate the padding needed
-
     original_bytes = len(original_data)
-    padding_bytes = (3 - original_bytes % 3) % 3
+    padding_bytes = int(math.pow(math.isqrt(original_bytes) + 1, 2) - original_bytes) * 3
 
     # pad the byte data
     byte_data = original_data + b'\x00' * padding_bytes
 
     # Calculate total pixels and find width and height
     total_pixels = len(byte_data) // 3
+
     width = height = math.isqrt(total_pixels)
 
     # Convert the bytes to an image
@@ -71,6 +71,7 @@ def encode():
 
         else:
             print("advanced integrity check skipped.")
+
 
 def decode():
     # Open the image


### PR DESCRIPTION
This PR should address the issue, where data is lost at the the encoding phase.

Resolves Issue  #1 .

The `padding_bytes` are calculated by rounding the `original_bytes` to the next highest sqrt.
Then the power of two is taken to make it a square. And this  value is then subtracted from the `original_bytes` to get the needed `padding_bytes`.

Tested on following files:

- main.py
- LICENSE
- a PDF file
- a MP4 file

Hope it helps. This is my first PR. 